### PR TITLE
[fix] refs 7 ignorepathsの追加

### DIFF
--- a/cspell/cspell.config.yaml
+++ b/cspell/cspell.config.yaml
@@ -9,3 +9,5 @@ dictionaries:
 ignorePaths:
   - "cspell.config.yaml"
   - "../.github/CODEOWNERS"
+  - "../README.md"
+  - "../package.json"


### PR DESCRIPTION
READMEをCSpellの参照から除外した