### PR TITLE
Cspellのdictionaryに単語追加 

### DIFF
--- a/cspell/dictionary.txt
+++ b/cspell/dictionary.txt
@@ -1,5 +1,8 @@
-hontokun
-buildx
-kouxi
 Avenir
+buildx
+datepicker
+hontokun
+kouxi
+pinia
+vuepic
 vuex


### PR DESCRIPTION
# 概要
Cspellのdiciotnaryに[pinia,vuepic,datepicker]の3つを追加しました。
# 関連issue
[Cspellの追加#14](https://github.com/kouxi08/Hontokun-frontend/issues/14)