### PR TITLE
ニュースから解説の切り替え

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,9 +28,7 @@ module.exports = {
         component: 'always' // コンポーネントは自己閉じ
       }
     }],
-    "vue/html-closing-bracket-newline": ["error", {
-      "singleline": "never",
-    }],
+    "vue/html-closing-bracket-newline": "off",
     "vue/v-on-event-hyphenation": "off",
     "vue/html-quotes": "error"
   }

--- a/.prettierrc
+++ b/.prettierrc
@@ -7,7 +7,7 @@
   "trailingComma": "es5",
   "bracketSpacing": true,
   "arrowParens": "always",
-  "bracketSameLine": false,
+  "bracketSameLine": true,
   "vueIndentScriptAndStyle": true,
   "singleAttributePerLine": false
 }

--- a/src/components/ExplainComponent.vue
+++ b/src/components/ExplainComponent.vue
@@ -2,33 +2,19 @@
   <div class="font-zenMaru mx-[48px] p-[16px] shadow-lg rounded-[8px] flex flex-col">
     <!-- Header Section -->
     <div class="w-full h-[40px] grid grid-cols-3 justify-between items-center top-4">
-      <Icon name="card-left" width="24" height="24" />
+      <Icon name="card-left" width="24" height="24" @click="showNews" class="cursor-pointer" />
       <p class="font-bold text-[16px] text-center">解説</p>
       <Button size="xs" color="danger" class="justify-self-end">報告</Button>
     </div>
 
     <!-- 本当のニュースかフェイクかフェイクか -->
-    <div
-      v-if="type === 'true_or_false'"
-      class="w-full grid grid-cols-3 justify-between items-center pt-[24px]"
-    >
-      <p
-        class="justify-self-start bg-accent font-bold text-white text-[16px] py-[4px] px-[8px] rounded-[8px]"
-      >
+    <div v-if="type === 'true_or_false'" class="w-full grid grid-cols-3 justify-between items-center pt-[24px]">
+      <p class="justify-self-start bg-accent font-bold text-white text-[16px] py-[4px] px-[8px] rounded-[8px]">
         正解
       </p>
-      <Icon
-        class="justify-self-center"
-        :name="answer === 'true' ? 'correct' : 'incorrect'"
-        width="24"
-        height="24"
-      />
-      <a
-        v-if="answer === 'true'"
-        class="justify-self-end text-blue-500 text-[12px] font-bold"
-        href="example.com"
-        target="_blank"
-      >
+      <Icon class="justify-self-center" :name="answer ? 'correct' : 'incorrect'" width="24" height="24" />
+      <a v-if="answer === 'true'" class="justify-self-end text-blue-500 text-[12px] font-bold" href="example.com"
+        target="_blank">
         ニュース記事へ
       </a>
     </div>
@@ -36,27 +22,18 @@
     <!-- Multiple Choice Section -->
     <div v-if="type === 'multiple_choice'" class="mt-[16px]">
       <!-- 正解表示 -->
-      <div
-        v-if="answer === 'true'"
-        class="w-full grid grid-cols-3 justify-between items-center pt-[24px]"
-      >
-        <p
-          class="justify-self-start bg-accent font-bold text-white text-[16px] py-[4px] px-[8px] rounded-[8px]"
-        >
+      <div v-if="answer === 'true'" class="w-full grid grid-cols-3 justify-between items-center pt-[24px]">
+        <p class="justify-self-start bg-accent font-bold text-white text-[16px] py-[4px] px-[8px] rounded-[8px]">
           正解
         </p>
         <p class="font-bold text-[16px] text-center">正解の選択肢</p>
-        <div
-          v-for="(option, index) in options"
-          :key="index"
-          class="flex items-center justify-center w-[200px] h-[50px] border-[3px] rounded-md"
-          :class="{
+        <div v-for="(option, index) in options" :key="index"
+          class="flex items-center justify-center w-[200px] h-[50px] border-[3px] rounded-md" :class="{
             'border-red-500 text-red-500': index === correctIndex && indexColor === 'red',
             'border-yellow-500 text-yellow-500': index === correctIndex && indexColor === 'yellow',
             'border-green-500 text-green-500': index === correctIndex && indexColor === 'green',
             'border-blue-500 text-blue-500': index === correctIndex && indexColor === 'blue',
-          }"
-        >
+          }">
           <Icon name="check-circle" width="24" height="24" class="mr-2" />
           <span class="font-bold text-[14px]">{{ option }}</span>
         </div>
@@ -68,10 +45,8 @@
       <p class="text-black font-bold text-[12px] px-[8px] flex-1">
         {{ keyword }}
       </p>
-      <button
-        class="bg-primary text-black font-bold text-[14px] py-[6px] px-[16px] rounded-full shadow"
-        @click="searchGoogle"
-      >
+      <button class="bg-primary text-black font-bold text-[14px] py-[6px] px-[16px] rounded-full shadow"
+        @click="searchGoogle">
         検索
       </button>
     </div>
@@ -84,50 +59,57 @@
 </template>
 
 <script setup>
-  import Button from "./ButtonComponent.vue";
-  import Icon from "./IconComponent.vue";
+import Button from "./ButtonComponent.vue";
+import Icon from "./IconComponent.vue";
 
-  const props = defineProps({
-    type: {
-      type: String,
-      required: true,
-      validator: (value) => ["true_or_false", "multiple_choice"].includes(value), // Validate quiz type
-    },
-    answer: {
-      type: Boolean,
-    },
-    explanation: {
-      type: String,
-      required: true,
-    },
-    keyword: {
-      type: String,
-      default: "",
-    },
-    options: {
-      type: Array,
-      default: () => [], // Options for multiple_choice type
-    },
-    correctIndex: {
-      type: Number,
-      default: -1, // Correct index for multiple_choice type
-    },
-  });
+const props = defineProps({
+  type: {
+    type: String,
+    required: true,
+    validator: (value) => ["true_or_false", "multiple_choice"].includes(value), // Validate quiz type
+  },
+  answer: {
+    type: Boolean,
+    required: true
+  },
+  explanation: {
+    type: String,
+    required: true,
+  },
+  keyword: {
+    type: String,
+    default: "",
+  },
+  options: {
+    type: Array,
+    default: () => [], // Options for multiple_choice type
+  },
+  correctIndex: {
+    type: Number,
+    default: -1, // Correct index for multiple_choice type
+  },
+});
 
-  // State management
-  import { ref } from "vue";
+// State management
+import { ref } from "vue";
 
-  const isAnswered = ref(false); // Track if the question has been answered
-  const selectedOption = ref(null); // Track the selected option index
+const isAnswered = ref(false); // Track if the question has been answered
+const selectedOption = ref(null); // Track the selected option index
 
-  function handleAnswer(index) {
-    selectedOption.value = index; // Store the selected option index
-    isAnswered.value = true; // Mark as answered
-  }
+const emit = defineEmits(['showNewsEvent']);
 
-  function searchGoogle() {
-    const query = encodeURIComponent(keyword); // URL encode the keyword
-    const googleSearchUrl = `https://www.google.com/search?q=${query}`;
-    window.open(googleSearchUrl, "_blank"); // Open search in a new tab
-  }
+const showNews = () => {
+  emit('showNewsEvent')
+}
+
+function handleAnswer(index) {
+  selectedOption.value = index; // Store the selected option index
+  isAnswered.value = true; // Mark as answered
+}
+
+function searchGoogle() {
+  const query = encodeURIComponent(keyword); // URL encode the keyword
+  const googleSearchUrl = `https://www.google.com/search?q=${query}`;
+  window.open(googleSearchUrl, "_blank"); // Open search in a new tab
+}
 </script>

--- a/src/components/NewsComponent.vue
+++ b/src/components/NewsComponent.vue
@@ -4,12 +4,11 @@
       <div class="relative">
         <img :src="props.img" alt="" class="w-full h-[104px] rounded-[6px] object-cover">
         <p
-          class="absolute w-full top-1/2 left-1/2 -translate-x-2/4 -translate-y-2/4 text-white pt-[24px] text-[14px] text-center font-notoSans tracking-widest font-bold stroke-black-4"
-        >
+          class="absolute w-full top-1/2 left-1/2 -translate-x-2/4 -translate-y-2/4 text-white pt-[24px] text-[14px] text-center font-notoSans tracking-widest font-bold stroke-black-4">
           {{ props.title }}
         </p>
         <div v-if="props.showResult">
-          <Button size="sm" color="accent" class="absolute top-0 left-0 m-[8px]">解説</Button>
+          <Button size="sm" color="accent" class="absolute top-0 left-0 m-[8px]" @click="showExplain">解説</Button>
           <Button size="sm" color="danger" class="absolute top-0 right-0 m-[8px]">報告</Button>
         </div>
       </div>
@@ -21,24 +20,31 @@
 </template>
 
 <script setup>
-import Button from './ButtonComponent.vue'
+import Button from "./ButtonComponent.vue";
 const props = defineProps({
   title: {
     type: String,
-    required: true
+    required: true,
   },
   content: {
     type: String,
-    required: true
+    required: true,
   },
   img: {
     type: String,
-    required: true
+    required: true,
   },
   showResult: {
     type: Boolean,
     default: false,
     type: String,
-  }
+  },
 });
+
+
+const emit = defineEmits(['showExplainEvent']);
+
+const showExplain = () => {
+  emit('showExplainEvent')
+}
 </script>

--- a/src/components/page/mainPage.vue
+++ b/src/components/page/mainPage.vue
@@ -6,8 +6,9 @@
           <Level />
           <XP value="4" class="bg-white border-2 border-primary rounded-[4px]" />
         </div>
-        <div class="bg-[#FDFDFD] rounded-full p-[8px] shadow-[0_0_4px_0_rgba(171,171,171,0.25)] cursor-pointer">
-          <Icon name="user" @click="router.push({ name: 'profilePage' })" />
+        <div class="bg-[#FDFDFD] rounded-full p-[8px] shadow-[0_0_4px_0_rgba(171,171,171,0.25)] cursor-pointer"
+          @click="router.push({ name: 'profilePage' })">
+          <Icon name="user" />
         </div>
       </div>
       <div v-if="!page.component">
@@ -20,8 +21,7 @@
         <img src="/hontokun.png" alt="" class="mx-auto my-[16px]">
         <button
           class="w-[136px] h-[136px] bg-[#FF6633] rounded-full text-white text-[32px] border-4 border-white flex items-center justify-center font-black font-zenMaru shadow-[0_0_4px_0_rgba(171,171,171,0.25)] mx-auto mt-[120px] hover:translate-y-[2px]"
-          @click="page.setPage('モード選択', modePage)"
-        >
+          @click="page.setPage('モード選択', modePage)">
           クイズ
         </button>
       </div>
@@ -44,10 +44,10 @@ const router = useRouter()
 </script>
 
 <style>
-  .bg-custom {
-    width: 100%;
-    height: 100%;
-    background-image: url(../../../public/detective-offices.png);
-    background-position: center;
-  }
+.bg-custom {
+  width: 100%;
+  height: 100%;
+  background-image: url(../../../public/detective-offices.png);
+  background-position: center;
+}
 </style>

--- a/src/components/page/profileDetailPage.vue
+++ b/src/components/page/profileDetailPage.vue
@@ -4,10 +4,8 @@
     <div class="flex-shrink-0">
       <!-- ヘッダー -->
       <div class="w-full grid grid-cols-3 justify-between items-center pt-[64px] px-[48px]">
-        <Icon
-          name="arrow-left-line" width="24" height="24" class="justify-self-start cursor-pointer"
-          @click="router.push({ name: 'profilePage' })"
-        />
+        <Icon name="arrow-left-line" width="24" height="24" class="justify-self-start cursor-pointer"
+          @click="router.push({ name: 'profilePage' })" />
         <p class="font-zenMaru text-[16px] text-center">{{ catName }}</p>
         <Rate value="32" size="sm" class="justify-self-end" />
       </div>
@@ -25,9 +23,13 @@
         <Table :header="tableHeader" :content="tableContent" />
       </div>
       <!-- ニュース -->
-      <div v-for="quiz in quizSet" :key="quiz" class="flex flex-col gap-[24px] py-[24px]">
+      <div v-for="(quiz, index) in quizSet" :key="quiz" class="flex flex-col gap-[24px] py-[24px]">
         <NewsTitle :id="quiz.id" :title="quiz.newsTitle" />
-        <News :title="quiz.questionTitle" :img="quiz.img" :content="quiz.content" :show-result="true" />
+        <News v-if="isAnswerRevealed[index]" :title="quiz.questionTitle" :img="quiz.img" :content="quiz.content"
+          :show-result="true" @showExplainEvent="isAnswerRevealed[index] = !isAnswerRevealed[index]" />
+        <Explain v-else :type="explainData[index].type" :explanation="explainData[index].explanation"
+          :answer="explainData[index].answer" :keyword="explainData[index].keyword"
+          @showNewsEvent="isAnswerRevealed[index] = !isAnswerRevealed[index]" />
       </div>
     </div>
   </div>
@@ -41,8 +43,12 @@ import Input from '../InputComponent.vue'
 import Table from '../TableComponent.vue'
 import NewsTitle from '../NewsTitleComponent.vue'
 import News from '../NewsComponent.vue'
+import Explain from '../ExplainComponent.vue'
+import { ref } from 'vue'
 import { useRouter } from 'vue-router'
+
 const router = useRouter()
+
 const catName = "ふろしきネコ"
 const catImage = "/hurosiki.svg"
 const tableHeader = [
@@ -78,4 +84,27 @@ const quizSet = [
     content: "最新の研究によると、寝ることは実は時間の無駄だと判明。科学者たちは、睡眠時間を削減することで生産性が飛躍的に向上すると主張しています。この革新的な発見により、人々の生活様式が大きく変わる可能性があります。",
   }
 ]
+
+const explainData = [
+  {
+    type: "true_or_false",
+    answer: true,
+    explanation: "「台風15号」など台風番号で調べることでより検索しやすくなります。「関東」「接近」で関東に接近した台風の情報が検索で出てきやすくなります。",
+    keyword: "台風15号　関東　接近",
+  },
+  {
+    type: "true_or_false",
+    answer: false,
+    explanation: "「NASA」が公式発表されている記事を検索して、フェイクニュースか判断することができます。",
+    keyword: "NASA　宇宙ステーション　巨大UFO",
+  },
+  {
+    type: "true_or_false",
+    answer: false,
+    explanation: "「睡眠時間」が生産性に関係している記事を検索して、フェイクニュースか判断することができます。",
+    keyword: "睡眠時間　生産　無駄",
+  },
+]
+
+const isAnswerRevealed = ref(Array.from({ length: quizSet.length }, () => true))
 </script>


### PR DESCRIPTION
- Issue番号（例: #123）
- #89

## 概要
ニュースから解説の切り替え

## 変更内容
- メイン画面のプロフィールに遷移するアイコンのクリックを親に変更
- 解説の答えのifを文字列で判定していたので修正