### PR TITLE
メッセージに配列で渡すと動的に切り替わる&api取得時にロードがかかる

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,22 +1,9 @@
 <template>
-  <div v-if="isPageLoaded">
+  <div>
     <router-view />
-  </div>
-  <div v-else>
-    <LoadingPage />
   </div>
 </template>
 
 <script setup>
 import { firebase } from "./firebase.js"
-import LoadingPage from "@/components/page/loadingPage.vue"
-import { ref, onMounted } from "vue"
-
-const isPageLoaded = ref(false)
-
-onMounted(() => {
-  window.onload = () => {
-    isPageLoaded.value = true
-  }
-})
 </script>

--- a/src/components/modules/MessageComponent.vue
+++ b/src/components/modules/MessageComponent.vue
@@ -1,6 +1,7 @@
 <template>
-  <div class="mx-[32px] border-[3px] border-primary rounded-[24px] leading-[1.7rem] shadow-button
-      flex justify-center p-[16px] items-center text-center bg-white font-zenMaru font-bold animate-fadeIn">
+  <div
+    class="mx-[32px] border-[3px] border-primary rounded-[24px] leading-[1.7rem] shadow-button
+      flex justify-center p-[16px] items-center text-center bg-white font-zenMaru font-bold whitespace-pre-wrap animate-fadeIn">
     <slot></slot>
   </div>
 </template>

--- a/src/components/modules/MessageComponent.vue
+++ b/src/components/modules/MessageComponent.vue
@@ -2,6 +2,26 @@
   <div
     class="mx-[32px] border-[3px] border-primary rounded-[24px] leading-[1.7rem] shadow-button
       flex justify-center p-[16px] items-center text-center bg-white font-zenMaru font-bold whitespace-pre-wrap animate-fadeIn">
-    <slot></slot>
+    {{ messages[currentMessage] }}
   </div>
 </template>
+
+<script setup>
+import { ref } from "vue"
+const props = defineProps({
+  messages: {
+    type: Array,
+    required: true,
+  },
+});
+
+const currentMessage = ref(0)
+
+setTimeout(() => {
+  if (currentMessage.value !== props.messages.length - 1) {
+    currentMessage.value++
+  }
+}, 3000);
+
+
+</script>

--- a/src/components/page/mainPage.vue
+++ b/src/components/page/mainPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-screen h-screen">
+  <div class="w-screen h-screen" v-if="loading">
     <div class="bg-detective-offices">
       <div class="flex justify-between items-center px-[24px] pt-[56px]">
         <div class="flex gap-[8px]">
@@ -13,10 +13,7 @@
       </div>
       <div>
         <Message class="mt-[5%]">
-          ようこそ！<br>
-          {{ user.nickname }}探偵事務所へ<br>
-          僕は助手のホントくん<br>
-          よろしくね！
+          {{ messages[0] }}
         </Message>
         <img :src="costume" alt="" class="mx-auto my-[16px] xs:w-[128px] md:w-[192px]">
         <button
@@ -27,6 +24,7 @@
       </div>
     </div>
   </div>
+  <LoadingPage v-else />
 </template>
 
 <script setup>
@@ -34,19 +32,29 @@ import Level from '@/components/modules/LevelComponent.vue'
 import XP from '@/components/modules/XpComponent.vue'
 import Icon from '@/components/modules/IconComponent.vue'
 import Message from '@/components/modules/MessageComponent.vue'
+import LoadingPage from '@/components/page/loadingPage.vue'
 import AxiosInstance from '@/axiosInstance.js'
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 const router = useRouter()
 const user = ref({})
 const costume = ref('')
+const loading = ref(false)
+const messages = ref([])
 
-onMounted(async () => {
-  const main = await AxiosInstance.get('/main')
-  user.value = main.data.user
-  costume.value = main.data.costume.url
+onMounted(async() => {
+  try {
+    const main = await AxiosInstance.get('/main')
+    user.value = main.data.user
+    costume.value = main.data.costume.url
+    loading.value = true
+    messages.value = [
+      `ようこそ！\n${user.value.nickname}探偵事務所へ\n僕は助手のホントくん\nよろしくね！`
+    ];
+  } catch (error) {
+    console.error('データの取得に失敗しました:', error)
+  }
 })
-
 </script>
 
 <style>

--- a/src/components/page/mainPage.vue
+++ b/src/components/page/mainPage.vue
@@ -12,9 +12,7 @@
         </div>
       </div>
       <div>
-        <Message class="mt-[5%]">
-          {{ messages[0] }}
-        </Message>
+        <Message class="mt-[5%]" :messages="messages" />
         <img :src="costume" alt="" class="mx-auto my-[16px] xs:w-[128px] md:w-[192px]">
         <button
           class="w-[136px] h-[136px] bg-[#FF6633] rounded-full text-white text-[32px] border-4 border-white flex items-center justify-center font-black font-zenMaru shadow-[0_0_4px_0_rgba(171,171,171,0.25)] mx-auto mt-[120px] hover:translate-y-[2px] md:mt-[32px] lg:mt-[40px]"
@@ -42,14 +40,14 @@ const costume = ref('')
 const loading = ref(false)
 const messages = ref([])
 
-onMounted(async() => {
+onMounted(async () => {
   try {
     const main = await AxiosInstance.get('/main')
     user.value = main.data.user
     costume.value = main.data.costume.url
     loading.value = true
     messages.value = [
-      `ようこそ！\n${user.value.nickname}探偵事務所へ\n僕は助手のホントくん\nよろしくね！`
+      `ようこそ！\n${user.value.nickname}探偵事務所へ\n僕は助手のホントくん\nよろしくね！`,
     ];
   } catch (error) {
     console.error('データの取得に失敗しました:', error)


### PR DESCRIPTION
- Issue番号（例: #123）
- #140 
- #150 

## 概要
メッセージに配列で渡すと動的に切り替わる&api取得時にロードがかかる

## 変更内容
- App.vueでページの取得を待つ処理を削除（ほぼ同時に行われるため）
- なおAPI取得時はメイン画面のみの実装（今後別issueにて実装）
- メッセージが動的にするために配列にする必要があり、slotでは行えないためpropsに変更
